### PR TITLE
Add Docker container with local networking and cybersecurity tools

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "build": "bash Install.sh"
+  }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# Use a suitable base image for a lean and compatible Linux distro
+FROM debian:latest
+
+# Set environment variables
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update and install necessary dependencies
+RUN apt-get update && \
+    apt-get install -y \
+    python3 \
+    python3-pip \
+    git \
+    curl \
+    wget \
+    openssh-client \
+    php \
+    neofetch \
+    figlet \
+    toilet \
+    jq \
+    ruby \
+    pv \
+    unzip \
+    && apt-get clean
+
+# Install Ciphey
+RUN git clone https://github.com/bee-san/Ciphey.git /opt/ciphey && \
+    cd /opt/ciphey && \
+    pip3 install -r requirements.txt && \
+    python3 -m pip install .
+
+# Install hackingtool
+RUN git clone https://github.com/Z4nzu/hackingtool.git /opt/hackingtool && \
+    cd /opt/hackingtool && \
+    chmod +x install.sh && \
+    ./install.sh
+
+# Copy AllHackingTools repository
+COPY . /opt/AllHackingTools
+
+# Set working directory
+WORKDIR /opt/AllHackingTools
+
+# Expose necessary ports
+EXPOSE 80 443 8080
+
+# Start the application
+CMD ["bash", "Install.sh"]

--- a/Install.sh
+++ b/Install.sh
@@ -17,6 +17,33 @@ apt install pip
 apt install pip2
 pip install requests
 pip2 install requests
+
+# Install Docker if not already installed
+if ! command -v docker &> /dev/null
+then
+    echo -e "$r Docker not found, installing... $w"
+    apt-get update
+    apt-get install -y docker.io
+    systemctl start docker
+    systemctl enable docker
+else
+    echo -e "$g Docker is already installed $w"
+fi
+
+# Install Docker Compose if not already installed
+if ! command -v docker-compose &> /dev/null
+then
+    echo -e "$r Docker Compose not found, installing... $w"
+    curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    chmod +x /usr/local/bin/docker-compose
+else
+    echo -e "$g Docker Compose is already installed $w"
+fi
+
+# Build and run the Docker container
+cd /path/to/AllHackingTools
+docker-compose up --build -d
+
 cd
 cd
 cd AllHackingTools

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ figlet -f block  AND  toilet -f block
 >>> qiq-bin       :cd to derictory
 ┬─┐o┌─┐┬  ┬─┐┌┐┐  ┌┐┐┬─┐┐ ┬  ┌─┐┌─┐┌┌┐┌┌┐┬─┐┌┐┐┬─┐┐─┐
 ├─ ││ ┬│  ├─  │    │││├─ │││  │  │ ││││││││─┤││││ │└─┐
-┆  ┆┆─┘┆─┘┴─┘ ┆   ┆└┘┴─┘└┴┆  └─┘┘─┘┘ ┆┘ ┆┘ ┆┆└┘┆─┘──┘
+┆  ┆┆─┘┆─┘┴─┘┆└┘  ┆└┘┴─┘└┴┆  └─┘┘─┘┘ ┆┘ ┆┘ ┆┆└┘┆─┘──┘
 >>> figlet -f Puffy   :no description
 >>> figlet -f Bloody  :no description
 >>> figlet -f Poison  :no description
@@ -471,4 +471,35 @@ Desing:
 ## Supporters
 [![Stargazers repo roster for @mishakorzik/AllHackingTools](https://reporoster.com/stars/mishakorzik/AllHackingTools)](https://github.com/mishakorzik/AllHackingTools/stargazers)
 [![Forkers repo roster for @mishakorzik/AllHackingTools](https://reporoster.com/forks/mishakorzik/AllHackingTools)](https://github.com/mishakorzik/AllHackingTools/members)
+
+## Docker Installation
+
+### Prerequisites
+
+- Docker
+- Docker Compose
+
+### Steps
+
+1. Clone the repository:
+
+```bash
+git clone https://github.com/mishakorzik/AllHackingTools.git
+cd AllHackingTools
+```
+
+2. Build and run the Docker container:
+
+```bash
+docker-compose up --build
+```
+
+3. Access the AllHackingTools application:
+
+Open your web browser and navigate to `http://localhost:80`.
+
+### Included Repositories
+
+- [Ciphey](https://github.com/bee-san/Ciphey)
+- [hackingtool](https://github.com/Z4nzu/hackingtool)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+
+services:
+  allhackingtools:
+    build: .
+    container_name: allhackingtools_container
+    ports:
+      - "80:80"
+      - "443:443"
+      - "8080:8080"
+    networks:
+      - allhackingtools_network
+
+networks:
+  allhackingtools_network:
+    driver: bridge


### PR DESCRIPTION
Add Docker support with local networking and include Ciphey and hackingtool repositories.

* **Dockerfile**: Create a Dockerfile to set up a suitable Linux instance with Ciphey and hackingtool repositories. Install necessary dependencies and configure the Dockerfile to enable local networking (bridge).
* **docker-compose.yml**: Create a `docker-compose.yml` file to configure Docker with local networking (bridge) enabled. Define services and networks.
* **README.md**: Update the `README.md` with instructions on how to build and run the Docker container. Include information about Ciphey and hackingtool repositories.
* **Install.sh**: Update the `Install.sh` to include steps for building and running the Docker container. Ensure the `Install.sh` script installs Docker and Docker Compose if not already installed.
* **.devcontainer/devcontainer.json**: Add a devcontainer configuration file to define build tasks.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mishakorzik/AllHackingTools/pull/134?shareId=ea1f84a1-379a-4d2c-94c9-2feb43744962).